### PR TITLE
add sources and targets to index and dropdown

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -2,13 +2,18 @@
 
 Couple steps are needed before you get productive
 
-If you are already logged in check out our guides:
+If you are already logged in, check out our guides:
 
 * [Getting Started](./guides/gettingstarted/). Create a Hello World service.
 * [Bridges](./guides/bridge/). Understanding and creating Bridges.
 * [Secrets](./guides/secrets/). Create and use secrets to store API keys.
 
-If you need to sign-up for the section below.
+Sources and Targets are documented at:
+
+* [Sources](./sources/)
+* [Targets](./targets/)
+
+If you need to sign-up, check the section below.
 
 ## Sign-up
 

--- a/docs/sources/index.md
+++ b/docs/sources/index.md
@@ -1,6 +1,6 @@
 # Event sources
 
-The following is a list of Triggermesh event Sources some available as open source projects some available as hosted solutions on our Cloud.
+The following is a list of Triggermesh event Sources, some available as open source projects, some available as hosted solutions on our Cloud.
 
 ## Current TriggerMesh Sources
 

--- a/docs/sources/index.md
+++ b/docs/sources/index.md
@@ -1,7 +1,6 @@
 # Event sources
 
-The Triggermesh event Sources are still under active development so this document will be evolving rapidly over the next
-months. Feel free to regularly check back for updates on current Targets as well as the addition of new ones!
+The following is a list of Triggermesh event Sources some available as open source projects some available as hosted solutions on our Cloud.
 
 ## Current TriggerMesh Sources
 
@@ -14,11 +13,14 @@ months. Feel free to regularly check back for updates on current Targets as well
 * [AWS SQS](./awssqs.md):
 * [Azure Activity Logs](./azureactivitylogs.md): Consume Activity Logs from a given Azure Subscription.
 * [Azure Event Hub](./azureeventhub.md):
+* [Slack](./slack.md):
+
+<!---
 * [Azure Storage](./azurestorage.md):
 * [Azure Storage Queue](./azurestoragequeue.md):
 * [Google Fire Store](./googlefirestore.md):
 * [Google Pub Sub](./googlepubsub.md):
 * [IBM MQ](./mq.md):
-* [Slack](./slack.md):
 * [Solace AMQP](./solace.md):
 * [Solace MQTT](./solacemqtt.md):
+--->

--- a/docs/sources/index.md
+++ b/docs/sources/index.md
@@ -4,16 +4,7 @@ The following is a list of Triggermesh event Sources, some available as open sou
 
 ## Current TriggerMesh Sources
 
-* [AWS Code Commit](./awscodecommit.md):
-* [AWS Cognito](./awscognito.md):
-* [AWS Dynamo DB](./awsdynamodb.md):
-* [AWS IOT](./awsiot.md):
-* [AWS Kinesis](./awskinesis.md):
-* [AWS SNS](./awssns.md):
-* [AWS SQS](./awssqs.md):
 * [Azure Activity Logs](./azureactivitylogs.md): Consume Activity Logs from a given Azure Subscription.
-* [Azure Event Hub](./azureeventhub.md):
-* [Slack](./slack.md):
 
 <!---
 * [Azure Storage](./azurestorage.md):

--- a/docs/targets/index.md
+++ b/docs/targets/index.md
@@ -1,15 +1,7 @@
 # Event targets
 
-The Triggermesh event Targets are still under active development so this document will be evolving rapidly over the next
-months. Feel free to regularly check back for updates on current Targets as well as the addition of new ones!
+The following is a list of Triggermesh event Destinations known as Targets. Some are available as open source projects some are available as hosted solutions on our Cloud.
 
 ## Current TriggerMesh Targets 
 
-* [Twillio](./twilio.md): Send SMS messages via Twillio
-* [AWS](./aws.md): Post events to several AWS services.
 * [AWS EventBridge](./awseventbridge.md): Forward arbitrary events to AWS EventBridge.
-* [Confluent](./confluent.md): Post events to Confluent
-* [Elastic Search](./elasticsearch.md): " "
-* [Google Sheets](./googlesheet.md): " "
-* [SendGrid](./sendgrid.md): Post events as E-mails via the SendGrid service
-* [Tekton](./tekton.md): " "

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,6 +15,20 @@ nav:
       - 'Usage': 'tm/usage.md'
       - 'Registry': 'tm/registry.md'
       - 'Serverless Manifest': 'tm/serverless.md'
+    - Sources:
+      - 'Azure Activity Logs': sources/azureactivitylogs.md
+      - 'AWS CodeCommit': sources/awscodecommit.md
+      - 'AWS SQS': sources/awssqs.md
+      - 'AWS Kinesis': sources/awskinesis.md
+      - 'AWS SNS': sources/awssns.md
+      - 'AWS DynamoDB': sources/awsdynamodb.md
+    - Targets:
+      - 'EventBridge': targets/awseventbridge.md
+      - 'Twilio': targets/twilio.md
+      - 'ElasticSearch': targets/elasticsearch.md
+      - 'Confluent': targets/confluent.md
+      - 'Tekton': targets/tekton.md
+      - 'AWS Lambda': targets/aws.md
     - Cloud: https://cloud.triggermesh.io
     - About: about.md
 theme:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,18 +17,8 @@ nav:
       - 'Serverless Manifest': 'tm/serverless.md'
     - Sources:
       - 'Azure Activity Logs': sources/azureactivitylogs.md
-      - 'AWS CodeCommit': sources/awscodecommit.md
-      - 'AWS SQS': sources/awssqs.md
-      - 'AWS Kinesis': sources/awskinesis.md
-      - 'AWS SNS': sources/awssns.md
-      - 'AWS DynamoDB': sources/awsdynamodb.md
     - Targets:
       - 'EventBridge': targets/awseventbridge.md
-      - 'Twilio': targets/twilio.md
-      - 'ElasticSearch': targets/elasticsearch.md
-      - 'Confluent': targets/confluent.md
-      - 'Tekton': targets/tekton.md
-      - 'AWS Lambda': targets/aws.md
     - Cloud: https://cloud.triggermesh.io
     - About: about.md
 theme:


### PR DESCRIPTION
Small stop gap measure to show sources and target documentation.

we need to follow up in subsequent PR to go over all docs for sources and targets because some don't make sense through our console since they are very ko and kubectl centric.