### PR TITLE
Clarify when the default Event Hub is created

### DIFF
--- a/docs/sources/azureactivitylogs.md
+++ b/docs/sources/azureactivitylogs.md
@@ -125,7 +125,7 @@ In the Source creation form, give a name to the event source and add the followi
   selected when the list of categories is left empty.
 * [Event Hub name][eventhubs-create]: _(optional)_ Name of an Event Hub to send data to. When the Event Hub name is
   set, an Event Hub with the given name MUST already exist within the namespace. When it is not set, Azure creates an
-  Event Hub with the name `insights-activity-logs`.
+  Event Hub with the name `insights-activity-logs` upon reception of the first log entry.
 * [Tenant ID, Client ID, Client secret][sp-create]: Service Principal authentication credentials, as described in the
   previous sections.
 


### PR DESCRIPTION
There is subtlety about the default `insights-activity-logs` Event Hub created by Azure when the user leaves the Event Hub name blank: it isn't created immediately but rather **upon reception of the first event** (log). It is important to mention it, otherwise users may be waiting for something that may never be created, simply because their subscription is not generating any activity log