### PR TITLE
Document emitted/supported event types

### DIFF
--- a/docs/sources/azureactivitylogs.md
+++ b/docs/sources/azureactivitylogs.md
@@ -147,6 +147,12 @@ within the Azure Subscription.
 
 ![Event Hub messages](../images/azureactivitylogs-source/eventhub-1.png)
 
+## Event types
+
+The Azure Activity Logs event source emits events of the following type:
+
+* `com.microsoft.azure.monitor.activity-log`
+
 [activity-logs]: https://docs.microsoft.com/en-us/azure/azure-monitor/platform/activity-log
 [diag-settings]: https://docs.microsoft.com/en-us/azure/azure-monitor/platform/diagnostic-settings
 

--- a/docs/targets/awseventbridge.md
+++ b/docs/targets/awseventbridge.md
@@ -52,6 +52,10 @@ Your can now start creating rules that trigger on certain events in the AWS Even
 
 For more information about using AWS EventBridge, please refer to the [EventBridge user guide][userguide].
 
+## Event types
+
+The AWS EventBridge event target can consume events of any type.
+
 [intro]: https://docs.aws.amazon.com/eventbridge/latest/userguide/what-is-amazon-eventbridge.html
 [userguide]: https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-getting-set-up.html
 [event-bus]: https://docs.aws.amazon.com/eventbridge/latest/userguide/create-event-bus.html

--- a/docs/targets/splunk.md
+++ b/docs/targets/splunk.md
@@ -59,6 +59,10 @@ New events should now be visible in the _Search & Reporting_ app inside Splunk.
 
 For more information about using Splunk, please refer to the [Splunk documentation][docs].
 
+## Event types
+
+The Splunk event target can consume events of any type.
+
 [ce]: https://cloudevents.io/
 [ce-jsonformat]: https://github.com/cloudevents/spec/blob/v1.0/json-format.md
 


### PR DESCRIPTION
First stab at documenting emitted/supported event types, with the hope that future documentation pages will follow the pattern. Zendesk already does.