### PR TITLE
Redirect top level links to their respective index

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,10 +15,8 @@ nav:
       - 'Usage': 'tm/usage.md'
       - 'Registry': 'tm/registry.md'
       - 'Serverless Manifest': 'tm/serverless.md'
-    - Sources:
-      - 'Azure Activity Logs': sources/azureactivitylogs.md
-    - Targets:
-      - 'EventBridge': targets/awseventbridge.md
+    - Sources: sources/index.md
+    - Targets: targets/index.md
     - Cloud: https://cloud.triggermesh.io
     - About: about.md
 theme:


### PR DESCRIPTION
Requiring the manual addition of each source and target to the top links is unlikely to scale: we will forget to add some of them, and the list will eventually overflow the browser window.

![image](https://user-images.githubusercontent.com/3299086/88092300-93958400-cb90-11ea-876d-1a6fce6308cb.png)
_simulation_

In this PR, I suggest that we point those top level links to their respective index instead, where we can organize sources and targets a bit more nicely.