### PR TITLE
AWS Target Doc Update

### DIFF
--- a/docs/targets/index.md
+++ b/docs/targets/index.md
@@ -4,6 +4,9 @@ The following is a list of Triggermesh event Destinations known as Targets. Some
 
 ## Current TriggerMesh Targets 
 
+* [AWS](./aws.md): Forward events to AWS services such as Lambda, SNS, SQS, and Kinesis.
 * [AWS EventBridge](./awseventbridge.md): Forward arbitrary events to AWS EventBridge.
+* [Elasticsearch](./elasticsearch.md): Send events to Elasticsarch to be indexed.
 * [Oracle](./oracle.md): Forward events to the Oracle Cloud.
+* [Slack](./slack.md): Forward events to Slack as messages to deliver immediately, scheduled, or as an update to a pre-existing message.
 * [Splunk](./splunk.md): Forward arbitrary events to Splunk


### PR DESCRIPTION
Clean up the AWS target docs a little bit to reflect the end user perspective instead of the TriggerMesh developer.