### PR TITLE
edit README for installation with pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ Install it with:
 pip install mkdocs
 ```
 
+If you have Python3, you may need to run 
+
+```
+pip3 install mkdocs
+```
+
 ## Serve the site locally
 
 ```


### PR DESCRIPTION
Edit README installation to show you may need to install mkdocs with pip3. I have Python3 and on my computer, I was not able to tun pip, but only could run pip3. 


closes https://github.com/triggermesh/docs/issues/50