### PR TITLE
Fix s3 documentation to reflect new default behavior of ce-subject and the io.triggermesh.awss3.object.put type

### DIFF
--- a/docs/targets/awss3.md
+++ b/docs/targets/awss3.md
@@ -43,38 +43,24 @@ For more information about using AWS S3, please refer to the [AWS documentation]
 
 ## Event Types
 
-### io.triggermesh.awss3.object.put
-
 Events of this type will store the event payload into an s3 bucket.
 
+The AWS S3 Target leaves the [CloudEvent][ce] type definition to the discretion of
+the implementer given the flexible nature of what can be stored in S3.  There is
+an exception if the `io.triggermesh.awss3.object.put` type is used where the target
+will store the payload body regardless of the `Discard CloudEvent context attributes` setting.
+
 The S3 bucket key used to store the event is defined by the `ce-subject` attribute.
-However, if `ce-subject` is not set, the default key will be: **ce-type**/**ce-source**/**ce-time**.
+If `ce-subject` is not set, the default key will be: **ce-type**/**ce-source**/**ce-time**.
 
 This type expects a [JSON][ce-jsonformat] payload with the following properties:
 
 | Name | Value | Description |
 |---|---|---|
-|**ce-type**|io.triggermesh.awss3.object.put|Event type denoting the s3 put request|
+|**ce-type**|io.triggermesh.awss3.object.put or user defined|Event type denoting the s3 put request|
 |**ce-subject**|string|The key to use with the assigned bucket for the Target|
 |**body**|[JSON][ce-jsonformat]|The data payload to store|
 
-The response [CloudEvent][ce] would have the following payload:
-
-| Name | Value | Description |
-|---|---|---|
-|**ce-type**|io.triggermesh.targets.aws.s3.result|Denotes a response payload from the S3 put request|
-|**ce-source**|`arn:aws:s3:...`|The S3's bucket ARN value as configured by the target|
-|**body**|[JSON][ce-jsonformat]|A JSON response from the Target invocation with the Etag associated with the request|
-
-### * Types
-
-The AWS S3 Target leaves the [CloudEvent][ce] type definition to the discretion of
-the implementer given the flexible nature of what can be stored in S3.  There is
-an exception for the `io.triggermesh.awss3.object.put`, documented above, where
-it will store the payload body regardless of the `Discard CloudEvent context attributes` setting.
-
-The S3 bucket key used to store the event is defined by the `ce-subject` attribute.
-However, if `ce-subject` is not set, the default key will be: **ce-type**/**ce-source**/**ce-time**.
 
 The response [CloudEvent][ce] would have the following payload:
 

--- a/docs/targets/awss3.md
+++ b/docs/targets/awss3.md
@@ -48,7 +48,7 @@ For more information about using AWS S3, please refer to the [AWS documentation]
 Events of this type will store the event payload into an s3 bucket.
 
 The S3 bucket key used to store the event is defined by the `ce-subject` attribute.
-However, if `ce-subject` is not set, the default key will be `**ce-type**/**ce-source**/**ce-time**`.
+However, if `ce-subject` is not set, the default key will be: **ce-type**/**ce-source**/**ce-time**.
 
 This type expects a [JSON][ce-jsonformat] payload with the following properties:
 
@@ -74,7 +74,7 @@ an exception for the `io.triggermesh.awss3.object.put`, documented above, where
 it will store the payload body regardless of the `Discard CloudEvent context attributes` setting.
 
 The S3 bucket key used to store the event is defined by the `ce-subject` attribute.
-However, if `ce-subject` is not set, the default key will be `**ce-type**/**ce-source**/**ce-time**`.
+However, if `ce-subject` is not set, the default key will be: **ce-type**/**ce-source**/**ce-time**.
 
 The response [CloudEvent][ce] would have the following payload:
 

--- a/docs/targets/awss3.md
+++ b/docs/targets/awss3.md
@@ -47,6 +47,9 @@ For more information about using AWS S3, please refer to the [AWS documentation]
 
 Events of this type will store the event payload into an s3 bucket.
 
+The S3 bucket key used to store the event is defined by the `ce-subject` attribute.
+However, if `ce-subject` is not set, the default key will be `**ce-type**/**ce-source**/**ce-time**`.
+
 This type expects a [JSON][ce-jsonformat] payload with the following properties:
 
 | Name | Value | Description |
@@ -59,10 +62,27 @@ The response [CloudEvent][ce] would have the following payload:
 
 | Name | Value | Description |
 |---|---|---|
-|**ce-type**|io.triggermesh.targets.aws.s3.result|Denotes a response payload from S3|
-|**ce-source**|`arn:aws:s3:...`|The S3 ARN value as configured by the target|
-|**body**|[JSON][ce-jsonformat]|A JSON response from the Target invocation|
+|**ce-type**|io.triggermesh.targets.aws.s3.result|Denotes a response payload from the S3 put request|
+|**ce-source**|`arn:aws:s3:...`|The S3's bucket ARN value as configured by the target|
+|**body**|[JSON][ce-jsonformat]|A JSON response from the Target invocation with the Etag associated with the request|
 
+### * Types
+
+The AWS S3 Target leaves the [CloudEvent][ce] type definition to the discretion of
+the implementer given the flexible nature of what can be stored in S3.  There is
+an exception for the `io.triggermesh.awss3.object.put`, documented above, where
+it will store the payload body regardless of the `Discard CloudEvent context attributes` setting.
+
+The S3 bucket key used to store the event is defined by the `ce-subject` attribute.
+However, if `ce-subject` is not set, the default key will be `**ce-type**/**ce-source**/**ce-time**`.
+
+The response [CloudEvent][ce] would have the following payload:
+
+| Name | Value | Description |
+|---|---|---|
+|**ce-type**|io.triggermesh.targets.aws.s3.result|Denotes a response payload from the S3 put request|
+|**ce-source**|`arn:aws:s3:...`|The S3's bucket ARN value as configured by the target|
+|**body**|[JSON][ce-jsonformat]|A JSON response from the Target invocation with the Etag associated with the request|
 
 
 [ce]: https://cloudevents.io/


### PR DESCRIPTION
Correct the documentation to reflect the default behavior of the io.triggermesh.awss3.object.put type. In addition, add documentation describing new default behavior of the `Ce-subject` CloudEvent attribute.