### PR TITLE
Override source to remove GitHub stars & forks

### DIFF
--- a/docs/overrides/partials/source.html
+++ b/docs/overrides/partials/source.html
@@ -1,0 +1,10 @@
+<div class="md-header__source">
+  <a href="https://github.com/triggermesh/docs/" title="Go to repository" class="md-source" >
+    <div class="md-source__icon md-icon">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path d="M439.55 236.05 244 40.45a28.87 28.87 0 0 0-40.81 0l-40.66 40.63 51.52 51.52c27.06-9.14 52.68 16.77 43.39 43.68l49.66 49.66c34.23-11.8 61.18 31 35.47 56.69-26.49 26.49-70.21-2.87-56-37.34L240.22 199v121.85c25.3 12.54 22.26 41.85 9.08 55a34.34 34.34 0 0 1-48.55 0c-17.57-17.6-11.07-46.91 11.25-56v-123c-20.8-8.51-24.6-30.74-18.64-45L142.57 101 8.45 235.14a28.86 28.86 0 0 0 0 40.81l195.61 195.6a28.86 28.86 0 0 0 40.8 0l194.69-194.69a28.86 28.86 0 0 0 0-40.81z"></path></svg>
+    </div>
+    <div class="md-source__repository">
+      Edit the docs on GitHub
+    </div>
+  </a>
+</div>


### PR DESCRIPTION
Fixes https://github.com/triggermesh/docs/issues/177

Sourced from
https://github.com/squidfunk/mkdocs-material/blob/master/src/partials/source.html
release 7.3.2 and the page source when rendered.

Signed-off-by: Matt Ray <github@mattray.dev>