### PR TITLE
improve admonition in guides

### DIFF
--- a/docs/guides/creatingasplitter.md
+++ b/docs/guides/creatingasplitter.md
@@ -2,13 +2,18 @@
 
 An event `Splitter` is part of the TriggerMesh routing solution. It has the simple purpose of splitting JSON arrays into multiple [CloudEvents](https://cloudevents.io/) for further processing.
 
-!!! Info "Prerequisites"
-    You need a working TriggerMesh platform installation. See the [installation steps](installation.md). You can verify that the API is available with the following command:
+!!! tip
+    You can verify that the API is available with the following command:
 
     ```console
     $ kubectl get crd splitters.routing.triggermesh.io
     NAME                               CREATED AT
     splitters.routing.triggermesh.io   2021-10-06T09:01:38Z
+    ```
+    
+    You can also explore the API specification with:
+    ```console
+    $ kubectl explain splitter
     ```
 
 ![](../assets/images/splitter.png)

--- a/docs/guides/doingatransformation.md
+++ b/docs/guides/doingatransformation.md
@@ -4,13 +4,18 @@ The `Transformation` object in TriggerMesh defines a set of operations that are
 sequentially applied to incoming CloudEvents. In this guide, we will create a
 simple flow (a.k.a Bridge) with an event producer and a transformation to see the declarative syntax that is used for modifying events.
 
-!!! Info "Prerequisites"
-    You need a working TriggerMesh platform installation. See the [installation steps](installation.md). You can verify that the API is available with the following command:
+!!! tip
+    You can verify that the API is available with the following command:
 
     ```console
     $ kubectl get crd transformations.flow.triggermesh.io
     NAME                                  CREATED AT
     transformations.flow.triggermesh.io   2021-10-06T09:01:40Z
+    ```
+    
+    You can also explore the API specification with:
+    ```console
+    $ kubectl explain transformation
     ```
 
 ![](../assets/images/transformation.png)

--- a/docs/guides/writingafunction.md
+++ b/docs/guides/writingafunction.md
@@ -2,14 +2,18 @@
 
 The TriggerMesh `Function` API provides opportunities to implement custom event flow logic and may act as a source, transformation, or a target. Currently, Python, NodeJS, and Ruby runtimes are supported.
 
-!!! Info "Prerequisites"
-    You need a working TriggerMesh platform installation. See the [installation steps](installation.md).
+!!! tip
     You can verify that the API is available with the following command:
 
     ```console
     $ kubectl get crd functions.extensions.triggermesh.io
     NAME                                  CREATED AT
     functions.extensions.triggermesh.io   2021-10-06T09:01:33Z
+    ```
+    
+    You can also explore the API specification with:
+    ```console
+    $ kubectl explain functions
     ```
 
 !!! Warning


### PR DESCRIPTION
This changes the admonitions in the guides from "info prereq" to "tip", removing the sentence about installing triggermesh and adding a `kubectl explain` syntax.