### PR TITLE
Remove leading dollar symbols in console commands

### DIFF
--- a/docs/guides/installation.md
+++ b/docs/guides/installation.md
@@ -28,7 +28,7 @@ If you are using VMware's [Tanzu Community Edition](https://tanzucommunityeditio
 All TriggerMersh APIs are implemented as Kubernetes CRDs, which we need to create before deploying the controller. The following `kubectl apply` command will create all of the CRDs.
 
 ```console
-$ kubectl apply -f https://github.com/triggermesh/triggermesh/releases/latest/download/triggermesh-crds.yaml
+kubectl apply -f https://github.com/triggermesh/triggermesh/releases/latest/download/triggermesh-crds.yaml
 ```
 
 ## Install the controller
@@ -36,7 +36,7 @@ $ kubectl apply -f https://github.com/triggermesh/triggermesh/releases/latest/do
 By default, the controller gets deployed in the `triggermesh` namespace. Deploy the controller with the following `kubectl apply` command:
 
 ```console
-$ kubectl apply -f https://github.com/triggermesh/triggermesh/releases/latest/download/triggermesh.yaml
+kubectl apply -f https://github.com/triggermesh/triggermesh/releases/latest/download/triggermesh.yaml
 ```
 
 ## Verifying the installation


### PR DESCRIPTION
The "copy to clipboard" icon on console commands also copies the dollar symbol, causing the paste to fail.  I think that removing the leading dollar symbols will make it easier to copy/paste the commands.