### PR TITLE
Add sink to Function YAML

### DIFF
--- a/docs/guides/bridges/webhook-to-slack.md
+++ b/docs/guides/bridges/webhook-to-slack.md
@@ -123,6 +123,11 @@ spec:
         "channel":"REPLACE-CHANNEL-ID",
         "text": event['message']
       }
+  sink:
+    ref:
+      apiVersion: eventing.knative.dev/v1
+      kind: Broker
+      name: default
 ```
 
 ## Routing Components


### PR DESCRIPTION
The sink is missing from the Function YAML, so the transformed event never goes back to the broker.