### PR TITLE
Remove invalid `DeleteMessageBatch` permission from IAM policy

### DIFF
--- a/docs/cloud/sources/awss3.md
+++ b/docs/cloud/sources/awss3.md
@@ -68,8 +68,7 @@ As an example, the following policy contains only the permissions required by th
             "Action": [
                 "sqs:GetQueueUrl",
                 "sqs:ReceiveMessage",
-                "sqs:DeleteMessage",
-                "sqs:DeleteMessageBatch"
+                "sqs:DeleteMessage"
             ],
             "Resource": "arn:aws:sqs:*:*:*"
         }

--- a/docs/cloud/sources/awssqs.md
+++ b/docs/cloud/sources/awssqs.md
@@ -62,8 +62,7 @@ and delete messages from any queue linked to the AWS account:
             "Action": [
                 "sqs:GetQueueUrl",
                 "sqs:ReceiveMessage",
-                "sqs:DeleteMessage",
-                "sqs:DeleteMessageBatch"
+                "sqs:DeleteMessage"
             ],
             "Resource": [
                 "arn:aws:sqs:*:*:*"


### PR DESCRIPTION
`DeleteMessageBatch` is an _action_, not a permission. AWS accepts it anyway, but shows a warning in the console.

`DeleteMessage` is the permission, and it is already included.