### PR TITLE
Add missing permission to pubsub docs

### DIFF
--- a/docs/cloud/sources/googlecloudpubsub.md
+++ b/docs/cloud/sources/googlecloudpubsub.md
@@ -25,6 +25,7 @@ that topic are provided in the [Pub/Sub Subscription](#pubsub-subscription-optio
 
 - `pubsub.subscriptions.create`
 - `pubsub.subscriptions.delete`
+- `pubsub.topics.attachSubscription`
 
 The predefined `roles/pubsub.editor` role is one example of role that is suitable for use with the TriggerMesh event
 source for Google Cloud Pub/Sub.


### PR DESCRIPTION
Comparing used/excess permissions with the `pubsub.editor` role resulted in this list when delegating subscription management. 

<img width="441" alt="Screen Shot 2022-11-18 at 11 11 09 AM" src="https://user-images.githubusercontent.com/445976/202784029-738e7ee1-875f-4ccc-be76-5e9cf77780de.png">
