### PR TITLE
Add missing permission to pubsubsource docs

### DIFF
--- a/docs/sources/googlecloudpubsub.md
+++ b/docs/sources/googlecloudpubsub.md
@@ -69,6 +69,7 @@ that topic are provided in the [Pub/Sub Subscription](#pubsub-subscription-optio
 
 - `pubsub.subscriptions.create`
 - `pubsub.subscriptions.delete`
+- `pubsub.topics.attachSubscription`
 
 The predefined `roles/pubsub.editor` role is one example of role that is suitable for use with the TriggerMesh event
 source for Google Cloud Pub/Sub.


### PR DESCRIPTION
Missing pubsub.topics.attachSubscription.

I am porting over a PR from  is an updated version of the PR from @rnewton https://github.com/triggermesh/docs/pull/300 