### PR TITLE
quickstart: brew command to install tmctl

### DIFF
--- a/docs/get-started/quickstart.md
+++ b/docs/get-started/quickstart.md
@@ -26,10 +26,9 @@ TriggerMesh CLI can be installed from different sources: brew repository, pre-bu
 
 === "Brew"
 
-    Coming soon...
-    <!-- ```
-    brew install tmctl
-    ``` -->
+    ```
+    brew install triggermesh/cli/tmctl
+    ```
 
 === "Pre-built binary"
 


### PR DESCRIPTION
also generates the auto completion for zsh and bash shells

source: https://github.com/triggermesh/homebrew-cli