### PR TITLE
Wire up triggermesh core API

### DIFF
--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -7,6 +7,7 @@ TriggerMesh is composed of a set of APIs representing:
 * Event Routing [components](./routing.md)
 * Declarative event [Transformation](./flow.md)
 * Event processing using [Function](./extensions.md)
+* Core TriggerMesh [eventing](./eventing.md)
 
 ## Repository structure
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -163,6 +163,7 @@ nav:
         - Routing: reference/routing.md
         - Transformation: reference/flow.md
         - Functions: reference/extensions.md
+        - Core: reference/eventing.md
 
 theme:
   name: material


### PR DESCRIPTION
TriggerMesh Core (the `eventing.triggermesh.io` group) needs to be linked from docs.