### PR TITLE
redirect unversioned links to the latest version

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 .git/
 *.sublime-project
 *.sublime-workspace
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
 FROM nginx
 
 COPY . /usr/share/nginx/html/
-
+COPY default.conf /etc/nginx/conf.d/

--- a/default.conf
+++ b/default.conf
@@ -1,0 +1,50 @@
+server {
+    listen       80;
+    listen  [::]:80;
+    server_name  localhost;
+
+    #access_log  /var/log/nginx/host.access.log  main;
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+    }
+
+    # redirect unversioned links
+    location ~ ^/(get-started|installation|overrides|schemas|sources|transformation|brokers|guides|observability|reference|targets)/ {
+        rewrite ^(.*)$ /latest/$1 last;
+    }
+
+    #error_page  404              /404.html;
+
+    # redirect server error pages to the static page /50x.html
+    #
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+
+    # proxy the PHP scripts to Apache listening on 127.0.0.1:80
+    #
+    #location ~ \.php$ {
+    #    proxy_pass   http://127.0.0.1;
+    #}
+
+    # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
+    #
+    #location ~ \.php$ {
+    #    root           html;
+    #    fastcgi_pass   127.0.0.1:9000;
+    #    fastcgi_index  index.php;
+    #    fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
+    #    include        fastcgi_params;
+    #}
+
+    # deny access to .htaccess files, if Apache's document root
+    # concurs with nginx's one
+    #
+    #location ~ /\.ht {
+    #    deny  all;
+    #}
+}
+


### PR DESCRIPTION
since adding multiple versions, the old links that appear on blog posts were broken. This PR redirects such requests to the latest release docs
 
fe. https://docs.staging.triggermesh.io/sources/googlecloudpubsub/ is broken and this PR will fix it